### PR TITLE
Added a setDelagate call on didReceiveCall for NXMCall object. Fixes …

### DIFF
--- a/app-to-app-objc/AppToApp/AppToAppCall/CallViewController.m
+++ b/app-to-app-objc/AppToApp/AppToAppCall/CallViewController.m
@@ -90,6 +90,8 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         [self displayIncomingCallAlert:call];
     });
+    [call setDelegate:self];
+    self.call = call;
 }
 
 - (void)displayIncomingCallAlert:(NXMCall *)call {


### PR DESCRIPTION
Added a setDelagate call on didReceiveCall for NXMCall object. Fixes a bug where Callee display not hanging up when caller hangs up.

Attention: @abdulajet 

Problem Premise:
- Clients using the sample code are mentioning that the Callee does not hangup when Caller hangs-up.

Cause:
- No delegate is being set on didReceiveCall

Fix
- Add setDelegate snippet